### PR TITLE
Add CI Build Passing Badge into README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python](https://img.shields.io/badge/Language-Python-blue.svg)](https://python.org/)
-
+[![Build Status](https://github.com/CSCI-GA-2820-SU24-001/shopcarts/actions/workflows/workflow.yml/badge.svg)](https://github.com/CSCI-GA-2820-SU24-001/shopcarts/actions) 
 ## Overview
 
 This project implements the shopcarts service, which allows customers to make a collection of products they want to purchase. The service includes a REST API that provides CRUD operations for managing shopcarts and the items within them.


### PR DESCRIPTION
CI Build Passing Badge added into README file.
![image](https://github.com/CSCI-GA-2820-SU24-001/shopcarts/assets/19199845/61073268-b4ba-448a-8cf0-d6a24cec2758)
