### PR TITLE
Create and Add Deploy Image Task to CI/CD Pipeline

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -95,19 +95,3 @@ spec:
       workspaces:
         - name: source
           workspace: pipeline-workspace
-    - name: behave
-      params:
-        - name: base-url
-          value: $(params.BASE_URL)
-        - name: wait-seconds
-          value: '60'
-        - name: driver
-          value: chrome
-      runAfter:
-        - deploy-image
-      taskRef:
-        kind: Task
-        name: behave
-      workspaces:
-        - name: source
-          workspace: pipeline-workspace

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -81,3 +81,33 @@ spec:
       workspaces:
         - name: source
           workspace: pipeline-workspace
+    - name: deploy-image
+      params:
+        - name: image-name
+          value: $(params.IMAGE_NAME)
+        - name: manifest-dir
+          value: k8s
+      runAfter:
+        - buildah
+      taskRef:
+        kind: Task
+        name: deploy-image
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+    - name: behave
+      params:
+        - name: base-url
+          value: $(params.BASE_URL)
+        - name: wait-seconds
+          value: '60'
+        - name: driver
+          value: chrome
+      runAfter:
+        - deploy-image
+      taskRef:
+        kind: Task
+        name: behave
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace


### PR DESCRIPTION
## Added deploy-image task:
- Deploys Docker image to Kubernetes using $(params.IMAGE_NAME) and k8s manifest directory.
- Runs after buildah task.
- Uses pipeline-workspace.

## Files Modified:
pipeline.yaml