### PR TITLE
Create and Add Deploy Image Task to CI/CD Pipeline

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -100,4 +100,17 @@ spec:
       workspaces:
         - name: source
           workspace: pipeline-workspace
-      
+    - name: deploy-image
+      params:
+        - name: image-name
+          value: $(params.IMAGE_NAME)
+        - name: manifest-dir
+          value: k8s
+      runAfter:
+        - buildah
+      taskRef:
+        kind: Task
+        name: deploy-image
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace


### PR DESCRIPTION
## Added deploy-image task:
• Deploys Docker image to Kubernetes using $(params.IMAGE_NAME) and k8s manifest directory.
• Runs after buildah task.
• Uses pipeline-workspace.

## Files Modified:
pipeline.yaml
